### PR TITLE
Fix shape of the detector plane (closes #13)

### DIFF
--- a/src/DRRs.jl
+++ b/src/DRRs.jl
@@ -7,6 +7,9 @@ include("io.jl")
 export Camera, Detector, make_xrays, trace
 include("camera.jl")
 
+export get_basis
+include("utils.jl")
+
 # Sampling
 export make_coordinate_matrix, make_inverse_coordinate_matrix, trilinear
 include("sampling/trilinear.jl")

--- a/src/DRRs.jl
+++ b/src/DRRs.jl
@@ -4,7 +4,7 @@ module DRRs
 export CT, read_dicom
 include("io.jl")
 
-export Camera, Detector, make_plane, get_rays, trace
+export Camera, Detector, make_xrays, trace
 include("camera.jl")
 
 # Sampling

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -15,35 +15,44 @@ end
 """
 mutable struct Detector
     center::MVector{3,Float64}
-    normal::MVector{3,Float64}
     height::Int64
     width::Int64
     Δx::Float64
     Δy::Float64
 end
 
-function make_plane(detector::Detector)
-    d = detector.center' * normalize(detector.normal)
-    xs = ((-detector.height÷2:1:detector.height÷2) .* detector.Δx) .+ detector.center[1]
-    ys = ((-detector.width÷2:1:detector.width÷2) * detector.Δy) .+ detector.center[2]
-    xys = product(xs, ys)
-    zs = [findz(xy..., normalize(detector.normal)..., d) for xy in xys]
-    return [SVector(xy..., z) for (xy, z) in zip(xys, zs)]
-end
-
-findz(x, y, a, b, c, d) = (d - a * x - b * y) / c
-
 """
     Ray
 """
 mutable struct Ray
     origin::SVector{3,Float64}
-    direction::SVector{3,Float64}
+    target::SVector{3,Float64}
 end
 
-function get_rays(camera::Camera, detector::Detector)
-    directions = make_plane(detector) .|> pixel -> pixel - camera.center
-    return [Ray(camera.center, direction) for direction in directions]
+trace(t::Float64; ray::Ray) = ray.origin + (ray.target - ray.origin) * t
+
+"""
+    make_xrays
+
+Given a camera and detector, construct the rays eminating from the camera center
+and the detector plane which they hit.
+"""
+function make_xrays(camera::Camera, detector::Detector)
+    # Get the detector plane normal vector
+    n̂ = camera.center - detector.center |> normalize
+    d = detector.center' * n̂
+
+    # Construct the detector plane
+    xs = ((-detector.height÷2:1:detector.height÷2) .* detector.Δx) .+ detector.center[1]
+    ys = ((-detector.width÷2:1:detector.width÷2) * detector.Δy) .+ detector.center[2]
+    xys = product(xs, ys)
+    zs = [findz(xy..., n̂..., d) for xy in xys]
+    plane = [SVector(xy..., z) for (xy, z) in zip(xys, zs)]
+
+    # Get the rays
+    rays = [Ray(camera.center, target) for target in plane]
+
+    return rays
 end
 
-trace(t::Float64; ray::Ray) = ray.origin + ray.direction * t
+findz(x, y, a, b, c, d) = (d - a * x - b * y) / c

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -7,15 +7,15 @@ import Base: product
     Camera
 """
 mutable struct Camera
-    center::SVector{3,Float64}
+    center::MVector{3,Float64}
 end
 
 """
     Detector Plane
 """
 mutable struct Detector
-    center::SVector{3,Float64}
-    normal::SVector{3,Float64}
+    center::MVector{3,Float64}
+    normal::MVector{3,Float64}
     height::Int64
     width::Int64
     Δx::Float64

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -38,21 +38,21 @@ Given a camera and detector, construct the rays eminating from the camera center
 and the detector plane which they hit.
 """
 function make_xrays(camera::Camera, detector::Detector)
+
     # Get the detector plane normal vector
     n̂ = camera.center - detector.center |> normalize
-    d = detector.center' * n̂
+    u, v, w = get_basis(n̂)
+    @assert w ≈ n̂
 
     # Construct the detector plane
-    xs = ((-detector.height÷2:1:detector.height÷2) .* detector.Δx) .+ detector.center[1]
-    ys = ((-detector.width÷2:1:detector.width÷2) * detector.Δy) .+ detector.center[2]
-    xys = product(xs, ys)
-    zs = [findz(xy..., n̂..., d) for xy in xys]
-    plane = [SVector(xy..., z) for (xy, z) in zip(xys, zs)]
+    t = (-detector.height÷2:1:detector.height÷2) .* detector.Δx
+    s = (-detector.width÷2:1:detector.width÷2) * detector.Δy
+    get_coord(u, v, coef) = (coef .* (u, v)) |> sum |> x -> x + detector.center
+    plane = [get_coord(u, v, coef) for coef in product(t, s)]
 
     # Get the rays
     rays = [Ray(camera.center, target) for target in plane]
 
     return rays
-end
 
-findz(x, y, a, b, c, d) = (d - a * x - b * y) / c
+end

--- a/src/drr.jl
+++ b/src/drr.jl
@@ -1,7 +1,7 @@
 function DRR(ct::CT, detector::Detector, camera::Camera, spacing::Float64, sampling_function)
 
     # Make the rays in the projector
-    projector = get_rays(camera, detector)
+    projector = make_xrays(camera, detector)
 
     # Get the spatial dimensions of the volume
     nx, ny, nz = size(ct.volume)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,24 @@
+using LinearAlgebra
+using StaticArrays
+
+
+"""
+    get_basis
+
+Given a new vector, construct an orthonormal basis.
+"""
+function get_basis(a::MVector{3,Float64})
+    w = normalize(a)
+    t = get_noncollinear_vector(w) |> normalize
+    u = cross(t, w)
+    v = cross(u, w)
+    return u, v, w
+end
+
+
+function get_noncollinear_vector(w)
+    t = deepcopy(w)
+    i = argmin(abs.(w))
+    t[i] = 1
+    return t
+end

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -4,10 +4,10 @@ import PlotlyJS: plot
 
 
 """
-get_slice_{x,y,z}
+    get_slice_{x,y,z}
 
-    Get a slice of a CT volume along the x (coronal), y (sagittal) or z (transverse) axis.
-    The slice is plotted as an isosurface in Plotly.
+Get a slice of a CT volume along the x (coronal), y (sagittal) or z (transverse) axis. 
+The slice is plotted as an isosurface in Plotly.
 """
 function get_slice_x(i::Int64; vol, xs, ys, zs, ctkwargs...)
     X, Y, Z = mgrid([xs[i]], ys, zs)
@@ -30,10 +30,10 @@ function get_slice_z(i::Int64; vol, xs, ys, zs, ctkwargs...)
 end
 
 """
-plot_ct
+    plot_ct
 
-        Make a Plotly trace for the CT volume.
-        `ctkwargs...` is a dictionary of keyword arguments to pass to the isosurface function.
+ Make a Plotly trace for the CT volume.
+`ctkwargs...` is a dictionary of keyword arguments to pass to the isosurface function.
 """
 function plot_ct(ct::CT; x::Int64=256, y::Int64=256, z::Int64=66, ctkwargs...)
     # Get the coordinate spacings
@@ -50,9 +50,9 @@ end
 
 
 """
-plot_camera
+    plot_camera
 
-    Make a Plotly trace for the camera center a single point in a 3D scatterplot.
+Make a Plotly trace for the camera center a single point in a 3D scatterplot.
 """
 function plot_camera(camera::Camera)
     return scatter(
@@ -68,11 +68,11 @@ end
 
 
 """
-plot_detector
+    plot_detector
 
-    Make two traces: one for the detector plane with a 3D mesh, and another
-    for the rays emanating from the camera. The rays are created using multiple
-    3D lineplots. The rays are subsampled (every 10th ray) to reduce overhead.
+Make two traces: one for the detector plane with a 3D mesh, and another
+for the rays emanating from the camera. The rays are created using multiple
+3D lineplots. The rays are subsampled (every 10th ray) to reduce overhead.
 """
 function plot_detector(camera::Camera, detector::Detector; skips::Int64=20)
 
@@ -112,9 +112,9 @@ end
 
 
 """
-plot(ct::CT, camera::Camera, detector::Detector)
+    plot(ct::CT, camera::Camera, detector::Detector)
 
-    Overload the plot function to render the projector geometry.
+Overload the plot function to render the projector geometry.
 """
 function plot(ct::CT, camera::Camera, detector::Detector; ctkwargs...)
     traces = [
@@ -133,10 +133,10 @@ end
 
 
 """
-plot_drr
+    plot_drr
 
-    Plot the geometry and the resulting DRR.
-    NOTE: Very slow.
+Plot the geometry and the resulting DRR. 
+NOTE: Very slow.
 """
 function plot_drr(ct::CT, camera::Camera, detector::Detector; ctkwargs...)
 

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -72,8 +72,8 @@ plot_detector
 
     Make a Plotly trace for the detector plane with a 3D mesh.
 """
-function plot_detector(detector::Detector)
-    plane = make_plane(detector)
+function plot_detector(camera::Camera, detector::Detector)
+    plane = make_plane(camera, detector)
     pts = plane[[1, detector.height, end - detector.height + 1, end]]
     return mesh3d(
         name="Detector",
@@ -117,7 +117,12 @@ plot(ct::CT, camera::Camera, detector::Detector)
     Overload the plot function to render the projector geometry.
 """
 function plot(ct::CT, camera::Camera, detector::Detector; ctkwargs...)
-    traces = [plot_rays(camera, detector)..., plot_ct(ct; ctkwargs...)..., plot_camera(camera), plot_detector(detector)]
+    traces = [
+        plot_rays(camera, detector)...,
+        plot_ct(ct; ctkwargs...)...,
+        plot_camera(camera),
+        plot_detector(camera, detector)
+    ]
     layout = Layout(scene=attr(
         xaxis=attr(range=[-500, 1100]),
         yaxis=attr(range=[-500, 1100]),
@@ -141,7 +146,13 @@ function plot_drr(ct::CT, camera::Camera, detector::Detector; ctkwargs...)
         specs=[Spec(kind="scene") Spec(kind="xy")]
     )
 
-    traces = [plot_rays(camera, detector)..., plot_ct(ct::CT; ctkwargs...)..., plot_camera(camera), plot_detector(detector)]
+    # Plot the 3D geometric setup
+    traces = [
+        plot_rays(camera, detector)...,
+        plot_ct(ct; ctkwargs...)...,
+        plot_camera(camera),
+        plot_detector(camera, detector)
+    ]
     layout = Layout(scene=attr(
         xaxis=attr(range=[-500, 1100]),
         yaxis=attr(range=[-500, 1100]),
@@ -152,6 +163,7 @@ function plot_drr(ct::CT, camera::Camera, detector::Detector; ctkwargs...)
         add_trace!(fig, trace, row=1, col=1)
     end
 
+    # Plot the DRR
     p = heatmap(z=DRR(ct, detector, camera, 0.1, trilinear), colorscale="Greys")
     add_trace!(fig, p, row=1, col=2)
 


### PR DESCRIPTION
Closes #13

- Parameterize the normal vector with the detector center and camera center
- Parameterize the detector plane with two vectors orthogonal to the normal

Note that the selection of the orthonormal basis of the detector plane is arbitrary. Might have to specify rotational invariance in the future.